### PR TITLE
Update buf_read.rs

### DIFF
--- a/src/server/buf_read.rs
+++ b/src/server/buf_read.rs
@@ -36,6 +36,9 @@ impl<R: Read> CustomBufReader<R> {
             self.cap = try!(self.inner.read(&mut self.buf));
             self.pos = 0;
         } else if min > self.cap - self.pos {
+            for i in 0..min{
+                self.buf.push(0);
+            }
             self.cap += try!(self.inner.read(&mut self.buf[self.cap..]));
         }            
 


### PR DESCRIPTION
I tried to use this crate to upload big file to my rustful web application but it fails. self.inner.result returns an error . This is because the self.inner.read mtehod does not increase the buffer size.
We can easly do that by pushing 0, min times, before to call self.inner.read.
This solves my issue
